### PR TITLE
Avatars: Fetch avatars for websites with taken usernames

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,4 +14,4 @@ before_install:
   - cat test-requirements.txt >> requirements.txt
 
 script:
-  - python -m pytest -s
+  - python -m pytest -s -v

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,4 @@ termcolor==1.1.0
 Werkzeug==0.11.3
 wheel==0.24.0
 pyyaml==3.12
+beautifulsoup4==4.6.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,4 @@ Werkzeug==0.11.3
 wheel==0.24.0
 pyyaml==3.12
 beautifulsoup4==4.6.0
+parameterized==0.6.1

--- a/tests/test_data.yml
+++ b/tests/test_data.yml
@@ -1,5 +1,8 @@
 ---
 facebook:
+  avatar_usernames:
+    - "gyanlakhwani"
+    - "brianchesky"
   taken_usernames:
     - "manu.chroma"
     - "vijeth.kv"

--- a/tests/test_get_avatar.py
+++ b/tests/test_get_avatar.py
@@ -1,0 +1,56 @@
+import unittest
+import json
+import requests as r
+import yaml
+import pytest
+from parameterized import parameterized
+import logging
+import username_api
+import os.path
+
+data = yaml.load(open(os.path.join('tests', 'test_data.yml')))
+websites = yaml.load(open('websites.yml'))
+
+
+def load_test_cases(type):
+	res = []
+	for website in data:
+		if website == 'behance':
+			users = [None]
+		elif type == 'with_avatar':
+			if 'avatar_usernames' in data[website]:
+				users = data[website]['avatar_usernames']
+			else:
+				users = data[website]['taken_usernames']
+		else:
+			users = data[website]['available_usernames']
+		res.extend((website, user) for user in users)
+
+	return res
+
+
+def custom_name_func(testcase_func, param_num, param):
+	return '%s_%s' % (
+		testcase_func.__name__,
+		parameterized.to_safe_name('_'.join(str(x) for x in param.args)),
+	)
+
+
+class TestGet_avatar(object):
+
+	@parameterized.expand(load_test_cases('with_avatar'),
+						  testcase_func_name=custom_name_func)
+	def test_with_avatar(self, website, user):
+		if not user:
+			pytest.skip("website not supported")
+		link = username_api.check_username(website, user)['avatar']
+		response = r.get(link)
+		assert(response.headers.get('content-type', '').startswith('image/') or
+			   response.headers.get('content-type') == 'application/octet-stream')
+
+	@parameterized.expand(load_test_cases('without_avatar'),
+						  testcase_func_name=custom_name_func)
+	def test_without_avatar(self, website, user):
+		if not user:
+			pytest.skip("website not supported")
+		assert username_api.check_username(website, user)['avatar'] is None

--- a/tests/test_username_api.py
+++ b/tests/test_username_api.py
@@ -6,8 +6,9 @@ import random
 import pytest
 import logging
 import username_api
+import os.path
 
-data = yaml.load(open('tests/test_data.yml'))
+data = yaml.load(open(os.path.join('tests', 'test_data.yml')))
 websites = yaml.load(open('websites.yml'))
 
 invalid_username = '$very%long{invalid}user(name)'
@@ -28,10 +29,9 @@ def get_expected_response(website, user, status):
   return {
     'possible': True,
     'status': status,
-    'url': websites['urls'].get(website, 'https://{w}.com/{u}').format(
-      w=website,
-      u=user
-    )
+    'url': username_api.get_profile_url(website, user),
+    'avatar': username_api.get_avatar(website, user) if status == 200
+              else None
   }
 
 class TestUsernameApi(object):

--- a/tests/test_username_api.py
+++ b/tests/test_username_api.py
@@ -337,7 +337,7 @@ class TestUsernameApi(object):
     json_resp = json.loads(resp.get_data().decode())
     assert {
       'possible': False,
-      'url': 'https://in.pinterest.com/{}/'.format(invalid_username)
+      'url': 'https://in.pinterest.com/{}'.format(invalid_username)
     } == json_resp
 
   def test_instagram_format_checking(self):
@@ -364,5 +364,5 @@ class TestUsernameApi(object):
       json_resp = json.loads(resp.get_data().decode())
       assert {
         'possible': False,
-        'url': 'https://mbasic.facebook.com/{}/'.format(invalid_username)
+        'url': 'https://mbasic.facebook.com/{}'.format(invalid_username)
       } == json_resp

--- a/websites.yml
+++ b/websites.yml
@@ -1,9 +1,9 @@
 ---
 urls:
   behance: https://{w}.net/{u}
-  pinterest: https://in.{w}.com/{u}/
+  pinterest: https://in.{w}.com/{u}
   tumblr: https://{u}.{w}.com
-  facebook: https://mbasic.{w}.com/{u}/
+  facebook: https://mbasic.{w}.com/{u}
 username_patterns:
   pinterest:
     characters: a-zA-Z0-9_
@@ -46,3 +46,15 @@ username_patterns:
     invalid_patterns:
       - "\\.(com|net)"
       - "(\\.)\\1{1,}"  # consecutive '.' not allowed
+avatar:
+  behance: false
+  facebook: opengraph
+  github: opengraph
+  gitlab: opengraph
+  instagram: opengraph
+  pinterest:
+    key: image_xlarge_url
+  soundcloud: opengraph
+  tumblr: opengraph
+  twitter:
+    url: https://twitter.com/{u}/profile_image?size=original


### PR DESCRIPTION
Adds `get_avatar` to fetch avatars from all websites. Currently works for everything except Behance. Only works for Facebook if `profile == visible`(as expected). The function expects the user's page to exist, but handles most errors gracefully even if it doesn't(`['pinterest', 'gitlab']` are offenders of this).

Adds appropriate tests, maybe they should be mixed with test_username_check, but I think the repo could use some more breaking down into parts, perhaps this could be a start.

Closes #35 