### PR TITLE
Add new username rule for Github

### DIFF
--- a/websites.yml
+++ b/websites.yml
@@ -67,6 +67,8 @@ username_patterns:
     max_length: 39
     invalid_patterns:
       - "-{2,}"
+      - "^-"
+      - "-$"
   instagram:
     characters: a-zA-Z0-9_.
     available_min_length: 5


### PR DESCRIPTION
This is added since Github cannot start or end with hypen

Closes https://github.com/manu-chroma/username-availability-checker/issues/33