### PR TITLE
Remove MediumStaff from test data

### DIFF
--- a/tests/test_data.yml
+++ b/tests/test_data.yml
@@ -93,7 +93,6 @@ medium:
   invalid_usernames:
     - "$very%long{invalid}user(name)"
   taken_usernames:
-    - "MediumStaff"
     - "Medium"
   available_usernames:
     - "zNRe3jx3isA8CoM"

--- a/username_api.py
+++ b/username_api.py
@@ -172,7 +172,8 @@ def check_usable(website):
 
     if code == 404 or code == 301:
         usable = False
-    usable = True
+    else:
+        usable = True
     cache.set(identifier, usable, timeout=60*10)
 
     return usable


### PR DESCRIPTION
Although MediumStaff passes local test and codeship test:
https://app.codeship.com/projects/274884/builds/32247122,
it doesn't pass Travis CI several time:
* https://travis-ci.org/manu-chroma/username-availability-checker/builds/347315141
* https://travis-ci.org/manu-chroma/username-availability-checker/builds/347339603
* https://travis-ci.org/manu-chroma/username-availability-checker/builds/343095785

So, MediumStaff is removed from test data.

Solves https://github.com/manu-chroma/username-availability-checker/issues/79