### PR TITLE
Remove `gyanlakhwani` from avatar_usernames

### DIFF
--- a/tests/test_data.yml
+++ b/tests/test_data.yml
@@ -20,6 +20,7 @@ deviantart:
 facebook:
   avatar_usernames:
     - "brianchesky"
+    - "sheryl"
   invalid_usernames:
     - "hello..world"
     - "hell..."

--- a/tests/test_data.yml
+++ b/tests/test_data.yml
@@ -19,7 +19,6 @@ deviantart:
     - "zNRe3jx3isA8CoM"
 facebook:
   avatar_usernames:
-    - "gyanlakhwani"
     - "brianchesky"
   invalid_usernames:
     - "hello..world"


### PR DESCRIPTION
Since `gyanlakhwani` is hidden profile now,
it is improper as test case for avatar_usernames.