### PR TITLE
Set as raw string for avoiding pycodestyle W605

### DIFF
--- a/username_api.py
+++ b/username_api.py
@@ -58,7 +58,7 @@ def get_avatar(website, username):
     elif 'key' in data:
         # Searches for "`key`": "`link`"
         regex = re.compile('[\'\"]' + re.escape(data['key']) +
-                           '[\'\"]:(\s)?[\'\"](?P<link>[^\s]+)[\'\"]')
+                           r'[\'\"]:(\s)?[\'\"](?P<link>[^\s]+)[\'\"]')
         result = re.search(regex, response.text)
         if not result:
             return None


### PR DESCRIPTION
Since python 3.6, using invalid escape sequence is deprecated.
(Note: https://bugs.python.org/issue27364)
So the string should be raw string.