### PR TITLE
Add support for gravatar

### DIFF
--- a/frontend.py
+++ b/frontend.py
@@ -1,6 +1,7 @@
 import logging
 import os
 import sys
+import json
 
 from dotenv import load_dotenv
 from flask import Flask, request, render_template
@@ -24,6 +25,7 @@ PROTOCOL_BACKEND = os.environ.get('PROTOCOL_BACKEND')
 patterns = yaml.load(open('websites.yml'))
 
 sites = ' '.join(list(patterns['username_patterns'].keys()))
+logos = json.dumps(patterns['logos'])
 
 
 @app.route('/', methods=['GET'])
@@ -34,6 +36,7 @@ def my_form():
         return render_template('status.html',
                                username=username,
                                sites=sites,
+                               logos=logos,
                                host_backend=HOST_BACKEND,
                                port_backend=PORT_BACKEND,
                                protocol_backend=PROTOCOL_BACKEND)
@@ -47,6 +50,7 @@ def my_form_post():
     return render_template('status.html',
                            username=username,
                            sites=sites,
+                           logos=logos,
                            host_backend=HOST_BACKEND,
                            port_backend=PORT_BACKEND,
                            protocol_backend=PROTOCOL_BACKEND)

--- a/templates/status.html
+++ b/templates/status.html
@@ -63,14 +63,17 @@
         function main ()  {
             // list of supported websites
             var sites = "{{sites}}".split(" ");
+            var logos = JSON.parse({{ logos|tojson|safe }});
 
             // create cards dynamically for each of the websites
             sites.forEach(website => {
+              var logoElement = constructLogoElement(website, logos);
               $(".helper").append(`
                 <div class="card">
                     <p>
                         <div class="tooltip">
-                            <i class="fa fa-${website}"></i>
+                            <${logoElement.htmlElement} ${logoElement.htmlAttribute}="${logoElement.attributeValue}">
+                            </${logoElement.htmlElement}>
                             <span class="tooltiptext">${website}</span>
                         </div>
                         <span id='${website}'>
@@ -85,6 +88,49 @@
             sites.forEach(website => {
                 request_api(website);
             });
+        }
+
+        function constructLogoElement (website, logos) {
+            // defaults to font awesome icons
+            var logoElement = {
+                attributeValue: `fa fa-${website}`,
+                htmlAttribute: 'class',
+                htmlElement: 'i',
+            };
+
+            if (logos[website]) {
+                // the key defined in the yml. e.g., url, fontawesome
+                var ymlKey = Object.keys(logos[website])[0];
+                // determines html attribute to be used to display icon. e.g., src, class
+                logoElement.htmlAttribute = determineLogoHtmlAttribute(ymlKey);
+                // determines html element to be used based off of the attribute. e.g., i, img
+                logoElement.htmlElement = determineLogoHtmlElement(logoElement.htmlAttribute);
+                // gets the attribute value from the yml file.
+                logoElement.attributeValue = logos[website][ymlKey];
+            }
+            return logoElement;
+        }
+
+        function determineLogoHtmlElement(htmlAttribute) {
+            var element;
+            if (htmlAttribute === 'src') {
+                element = 'img';
+            } else if (htmlAttribute === 'class') {
+                element = 'i';
+            }
+            return element;
+        }
+
+        function determineLogoHtmlAttribute(key) {
+            var attribute;
+            if (key === 'url') {
+                attribute = 'src';
+            } else if (key === 'fontawesome') {
+                attribute = 'class';
+            } else {
+                console.error("Incorrect logo key in yml.")
+            }
+            return attribute;
         }
     </script>
 </head>

--- a/tests/test_data.yml
+++ b/tests/test_data.yml
@@ -91,6 +91,13 @@ behance:
     - "andrewda"
   available_usernames:
     - "zNRe3jx3isA8CoM"
+gravatar:
+  invalid_usernames:
+    - "$very%long{invalid}user(name)"
+  taken_usernames:
+    - "kaiusesthis"
+  available_usernames:
+    - "zNRe3jx3isA8CoM"
 tumblr:
   invalid_usernames:
     - "$very%long{invalid}user(name)"

--- a/username_api.py
+++ b/username_api.py
@@ -53,7 +53,10 @@ def get_avatar(website, username):
     elif 'html_selector' in data:
         soup = BeautifulSoup(response.text, 'html.parser')
         images = soup.select(data['html_selector'])
-        src = images[0]['src']
+        if website == 'gravatar':
+            src = images[0]['href']
+        else:
+            src = images[0]['src']
         return src
     elif 'key' in data:
         # Searches for "`key`": "`link`"

--- a/websites.yml
+++ b/websites.yml
@@ -4,6 +4,7 @@ urls:
   behance: https://{w}.net/{u}
   deviantart: https://{u}.{w}.com/
   facebook: https://mbasic.{w}.com/{u}
+  gravatar: https://en.{w}.com/{u}
   keybase: https://{w}.io/{u}
   medium: https://{w}.com/@{u}
   openhub: https://www.{w}.net/accounts/{u}
@@ -21,6 +22,7 @@ constant_usernames:
   facebook: "gyanlakhwani"
   github: "seeeturtle"
   gitlab: "andrewda"
+  gravatar: "kaiusesthis"
   instagram: "ElonMusk"
   keybase: "jayvdb"
   medium: "MediumStaff"
@@ -71,6 +73,11 @@ username_patterns:
       - "-{2,}"
       - "^-"
       - "-$"
+  gravatar:
+    characters: a-zA-Z0-9
+    available_min_length: 4
+    min_length: 4
+    max_length: 50
   instagram:
     characters: a-zA-Z0-9_.
     available_min_length: 5
@@ -131,6 +138,8 @@ avatar:
   facebook: opengraph
   github: opengraph
   gitlab: opengraph
+  gravatar:
+    html_selector: ".photo-0"
   instagram: opengraph
   keybase: opengraph
   medium: opengraph

--- a/websites.yml
+++ b/websites.yml
@@ -144,3 +144,9 @@ avatar:
   tumblr: opengraph
   twitter:
     url: https://twitter.com/{u}/profile_image?size=original
+logos:
+  # fontawesome: full class that you would normally put in a fontawesome element
+  facebook:
+    fontawesome: fa fa-facebook
+  keybase:
+    url: https://png.icons8.com/ios/30/000000/keybase.png


### PR DESCRIPTION
Add support for profile pictures and username checking for gravatar.

Closes https://github.com/manu-chroma/username-availability-checker/issues/37

Gravatar does not have their images as normal `img` tags, instead it has it as background pictures in an `a` tag. As a result, I have to parse for the `href` of the `a` tag, instead of the `src` of the `img` tag. Please advise if there is a better way to implement this.

Another method that I tried to use was directly getting the profile picture url through Gravatar's json api. (ex: https://en.gravatar.com/kaiusesthis.json). I tried to do that by adding a  `keys` key in the `websites.yml` file. However, this caused more headache down the road as this meant the link on the frontend would go to the json endpoint. Additionally, the regex that parsed the `keys` value did not work properly. It would return the wrong json. 

Would love to hear feedback on how to make this better.