### PR TITLE
Add functionality to specify custom icons

### DIFF
--- a/frontend.py
+++ b/frontend.py
@@ -1,6 +1,7 @@
 import logging
 import os
 import sys
+import json
 
 from dotenv import load_dotenv
 from flask import Flask, request, render_template
@@ -24,6 +25,7 @@ PROTOCOL_BACKEND = os.environ.get('PROTOCOL_BACKEND')
 patterns = yaml.load(open('websites.yml'))
 
 sites = ' '.join(list(patterns['username_patterns'].keys()))
+logos = json.dumps(patterns['logos'])
 
 
 @app.route('/', methods=['GET'])
@@ -34,6 +36,7 @@ def my_form():
         return render_template('status.html',
                                username=username,
                                sites=sites,
+                               logos=logos,
                                host_backend=HOST_BACKEND,
                                port_backend=PORT_BACKEND,
                                protocol_backend=PROTOCOL_BACKEND)
@@ -47,6 +50,7 @@ def my_form_post():
     return render_template('status.html',
                            username=username,
                            sites=sites,
+                           logos=logos,
                            host_backend=HOST_BACKEND,
                            port_backend=PORT_BACKEND,
                            protocol_backend=PROTOCOL_BACKEND)

--- a/templates/status.html
+++ b/templates/status.html
@@ -63,14 +63,17 @@
         function main ()  {
             // list of supported websites
             var sites = "{{sites}}".split(" ");
+            var logos = JSON.parse({{ logos|tojson|safe }});
 
             // create cards dynamically for each of the websites
             sites.forEach(website => {
+              var logoElement = constructLogoElement(website, logos);
               $(".helper").append(`
                 <div class="card">
                     <p>
                         <div class="tooltip">
-                            <i class="fa fa-${website}"></i>
+                            <${logoElement.htmlElement} ${logoElement.htmlAttribute}="${logoElement.attributeValue}">
+                            </${logoElement.htmlElement}>
                             <span class="tooltiptext">${website}</span>
                         </div>
                         <span id='${website}'>
@@ -85,6 +88,49 @@
             sites.forEach(website => {
                 request_api(website);
             });
+        }
+
+        function constructLogoElement (website, logos) {
+            // defaults to font awesome icons
+            var logoElement = {
+                attributeValue: `fa fa-${website}`,
+                htmlAttribute: 'class',
+                htmlElement: 'i',
+            };
+
+            if (logos[website]) {
+                // the key defined in the yml. e.g., url, fontawesome
+                var ymlKey = Object.keys(logos[website])[0];
+                // determines html attribute to be used to display icon. e.g., src, class
+                logoElement.htmlAttribute = determineLogoHtmlAttribute(ymlKey);
+                // determines html element to be used based off of the attribute. e.g., i, img
+                logoElement.htmlElement = determineLogoHtmlElement(logoElement.htmlAttribute);
+                // gets the attribute value from the yml file.
+                logoElement.attributeValue = logos[website][ymlKey];
+            }
+            return logoElement;
+        }
+
+        function determineLogoHtmlElement(htmlAttribute) {
+            var element;
+            if (htmlAttribute === 'src') {
+                element = 'img';
+            } else if (htmlAttribute === 'class') {
+                element = 'i';
+            }
+            return element;
+        }
+
+        function determineLogoHtmlAttribute(key) {
+            var attribute;
+            if (key === 'url') {
+                attribute = 'src';
+            } else if (key === 'fontawesome') {
+                attribute = 'class';
+            } else {
+                console.error("Incorrect logo key in yml.")
+            }
+            return attribute;
         }
     </script>
 </head>

--- a/websites.yml
+++ b/websites.yml
@@ -144,3 +144,9 @@ avatar:
   tumblr: opengraph
   twitter:
     url: https://twitter.com/{u}/profile_image?size=original
+logos:
+  # fontawesome: full class that you would normally put in a fontawesome element
+  facebook:
+    fontawesome: fa fa-facebook
+  keybase:
+    url: https://png.icons8.com/ios/30/000000/keybase.png


### PR DESCRIPTION
Add functionality to specify custom icons, either from an image or class, based on values set in websites.yml

Closes https://github.com/manu-chroma/username-availability-checker/issues/110

In the `websites.yml` file, people can now specify if they would like an image or a class to be used for the icon of a website. Keybase's  was added as an example. By specifying `src : ...` it will construct an image tag, and by specifying `class: ...` it will construct an `i` tag.

This code desperately needs a second pair of eyes to look at it and suggest feedback!